### PR TITLE
Allow passing null or undefined router to 1

### DIFF
--- a/src/express/pipelinebuilder.ts
+++ b/src/express/pipelinebuilder.ts
@@ -76,6 +76,8 @@ export type RouterDefinition =
   express.Router
   | RouteDefinition;
 
+export type RouterWithNullDef = RouterDefinition | null | undefined;
+
 export interface ComplexStaticDefinition {
   root: string;
   options?: Record<string, unknown>;
@@ -94,10 +96,10 @@ export interface LogOptions {
 }
 
 export interface PipelineSettings {
-  topLevels?: Array<express.Router | RouteDefinition | null>;
-  routes?: Array<express.Router | RouteDefinition | null>;
+  topLevels?: Array<RouterWithNullDef>;
+  routes?: Array<RouterWithNullDef>;
   statics?: Array<StaticDefinition>;
-  postStatics?: Array<express.Router | RouteDefinition | null>;
+  postStatics?: Array<RouterWithNullDef>;
   errorHandlers?: Array<express.ErrorRequestHandler>;
   options?: {
     log?: LogOptions;
@@ -264,7 +266,7 @@ export default class PipelineBuilder {
    */
   private _setRoutes(
     router: express.Router,
-    routes?: Array<RouterDefinition | null>,
+    routes?: Array<RouterWithNullDef>,
   ): void {
     (routes ?? []).filter<RouterDefinition>(
       (e): e is RouterDefinition => Boolean(e),

--- a/src/express/pipelinebuilder.ts
+++ b/src/express/pipelinebuilder.ts
@@ -72,6 +72,10 @@ export type RouteDefinition =
   ComplexRouteDefinition
   | express.RequestHandler;
 
+export type RouterDefinition =
+  express.Router
+  | RouteDefinition;
+
 export interface ComplexStaticDefinition {
   root: string;
   options?: Record<string, unknown>;
@@ -260,9 +264,11 @@ export default class PipelineBuilder {
    */
   private _setRoutes(
     router: express.Router,
-    routes?: Array<express.Router | RouteDefinition | null>,
+    routes?: Array<RouterDefinition | null>,
   ): void {
-    (routes ?? []).filter(e => e).forEach(routeDef => {
+    (routes ?? []).filter<RouterDefinition>(
+      (e): e is RouterDefinition => Boolean(e),
+    ).forEach(routeDef => {
       const asRouter = routeDef as express.Router;
       const asRouteDef = routeDef as ComplexRouteDefinition;
       const asRequestHandler = routeDef as express.RequestHandler;

--- a/src/express/pipelinebuilder.ts
+++ b/src/express/pipelinebuilder.ts
@@ -90,10 +90,10 @@ export interface LogOptions {
 }
 
 export interface PipelineSettings {
-  topLevels?: Array<express.Router | RouteDefinition>;
-  routes?: Array<express.Router | RouteDefinition>;
+  topLevels?: Array<express.Router | RouteDefinition | null>;
+  routes?: Array<express.Router | RouteDefinition | null>;
   statics?: Array<StaticDefinition>;
-  postStatics?: Array<express.Router | RouteDefinition>;
+  postStatics?: Array<express.Router | RouteDefinition | null>;
   errorHandlers?: Array<express.ErrorRequestHandler>;
   options?: {
     log?: LogOptions;
@@ -260,9 +260,9 @@ export default class PipelineBuilder {
    */
   private _setRoutes(
     router: express.Router,
-    routes?: Array<express.Router | RouteDefinition>,
+    routes?: Array<express.Router | RouteDefinition | null>,
   ): void {
-    (routes ?? []).forEach(routeDef => {
+    (routes ?? []).filter(e => e).forEach(routeDef => {
       const asRouter = routeDef as express.Router;
       const asRouteDef = routeDef as ComplexRouteDefinition;
       const asRequestHandler = routeDef as express.RequestHandler;


### PR DESCRIPTION
It allows to pass undefined or null router if you want to have dynamic router based on config or something else like
```javascript
app.use(createPipeline({
  topLevels: [
    config.enableCors && cors(),
  ],
  // [...]
});