### PR TITLE
Fix livereload port not being propagate to all watch tasks

### DIFF
--- a/src/grunt/reactapp.ts
+++ b/src/grunt/reactapp.ts
@@ -154,7 +154,7 @@ const createWatchTasks = (
         ? watchTask.taskToRun.split(":").join("_")
         : `unnamed${unnamedIndex++}`,
       {
-        options: {livereload: true},
+        options: getWatcherOptions(watchMode),
         files: watchTask.filesToWatch.reduce<Array<string>>(
           (acc, cur) => {
             const prefix = watchTask.fromRoot


### PR DESCRIPTION
The individuals tasks ignore the port set at top level of the watch task, this PR propagate the setting to all individuals watch tasks.